### PR TITLE
Consumer frequency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,18 +28,6 @@ pkg/audit/mocks/log.go:
 	mockgen -package=mocks -destination=pkg/audit/mocks/log.go ${PATH_COURIER}/pkg/audit Log
 	@ $(SED) 's/github.com\/trussle\/courier\/vendor\///g' ./pkg/audit/mocks/log.go
 
-pkg/cache/mocks/log.go:
-	mockgen -package=mocks -destination=pkg/cache/mocks/cache.go ${PATH_COURIER}/pkg/cache Cache
-	@ $(SED) 's/github.com\/trussle\/courier\/vendor\///g' ./pkg/cache/mocks/cache.go
-
-pkg/cache/cluster/mocks/peer.go:
-	mockgen -package=mocks -destination=pkg/cache/cluster/mocks/peer.go ${PATH_COURIER}/pkg/cache/cluster Peer
-	@ $(SED) 's/github.com\/trussle\/courier\/vendor\///g' ./pkg/cache/cluster/mocks/peer.go
-
-pkg/cache/members/mocks/members.go:
-	mockgen -package=mocks -destination=pkg/cache/members/mocks/members.go ${PATH_COURIER}/pkg/cache/members Members,MemberList,Member
-	@ $(SED) 's/github.com\/trussle\/courier\/vendor\///g' ./pkg/cache/members/mocks/members.go
-
 pkg/metrics/mocks/metrics.go:
 	mockgen -package=mocks -destination=pkg/metrics/mocks/metrics.go ${PATH_COURIER}/pkg/metrics Gauge,HistogramVec,Counter
 	@ $(SED) 's/github.com\/trussle\/courier\/vendor\///g' ./pkg/metrics/mocks/metrics.go
@@ -61,23 +49,16 @@ pkg/queue/mocks/queue.go:
 	@ $(SED) 's/github.com\/trussle\/courier\/vendor\///g' ./pkg/queue/mocks/queue.go
 
 .PHONY: build-mocks
-build-mocks: FORCE
-	@ $(MAKE) pkg/audit/mocks/log.go
-	@ $(MAKE) pkg/cache/cluster/mocks/peer.go
-	@ $(MAKE) pkg/cache/members/mocks/members.go
-	@ $(MAKE) pkg/cache/mocks/log.go
-	@ $(MAKE) pkg/metrics/mocks/metrics.go
-	@ $(MAKE) pkg/metrics/mocks/observer.go
-	@ $(MAKE) pkg/models/mocks/record.go
-	@ $(MAKE) pkg/models/mocks/transaction.go
-	@ $(MAKE) pkg/queue/mocks/queue.go
+build-mocks: pkg/audit/mocks/log.go \
+	pkg/metrics/mocks/metrics.go \
+	pkg/metrics/mocks/observer.go \
+	pkg/models/mocks/record.go \
+	pkg/models/mocks/transaction.go \
+	pkg/queue/mocks/queue.go
 
 .PHONY: clean-mocks
 clean-mocks: FORCE
 	rm -f pkg/audit/mocks/log.go
-	rm -f pkg/cache/cluster/mocks/peer.go
-	rm -f pkg/cache/members/mocks/members.go
-	rm -f pkg/cache/mocks/log.go
 	rm -f pkg/metrics/mocks/metrics.go
 	rm -f pkg/metrics/mocks/observer.go
 	rm -f pkg/models/mocks/record.go

--- a/cmd/courier/ingest.go
+++ b/cmd/courier/ingest.go
@@ -38,6 +38,7 @@ const (
 	defaultAWSSQSQueue       = ""
 	defaultAWSFirehoseStream = ""
 
+	defaultConsumerFrequency   = time.Second
 	defaultRecipientURL        = ""
 	defaultNumConsumers        = 2
 	defaultMaxNumberOfMessages = 10
@@ -65,6 +66,7 @@ func runIngest(args []string) error {
 		auditLogRootPath    = flags.String("auditlog.path", defaultAuditLogRootPath, "audit log root directory for the filesystem to use")
 		filesystemType      = flags.String("filesystem", defaultFilesystem, "type of filesystem backing (local, virtual, nop)")
 		recipientURL        = flags.String("recipient.url", defaultRecipientURL, "URL to hit with the message payload")
+		consumerFrequency   = flags.Duration("consumer.frequency", defaultConsumerFrequency, "frequency at which the consumer should run")
 		numConsumers        = flags.Int("num.consumers", defaultNumConsumers, "number of consumers to run at once")
 		maxNumberOfMessages = flags.Int("max.messages", defaultMaxNumberOfMessages, "max number of messages to dequeue at once")
 		visibilityTimeout   = flags.String("visibility.timeout", defaultVisibilityTimeout, "how long the visibility of a message should extended by in seconds")
@@ -264,6 +266,7 @@ func runIngest(args []string) error {
 				h.NewClient(timeoutClient, *recipientURL),
 				consumerQueue,
 				consumerLog,
+				*consumerFrequency,
 				consumedSegments,
 				consumedRecords,
 				replicatedSegments,

--- a/pkg/consumer/consumer.go
+++ b/pkg/consumer/consumer.go
@@ -31,6 +31,7 @@ type Consumer struct {
 	queue              queue.Queue
 	log                audit.Log
 	fifo               *fifo.FIFO
+	frequency          time.Duration
 	activeSince        time.Time
 	activeTargetAge    time.Duration
 	activeTargetSize   int
@@ -51,6 +52,7 @@ func New(
 	client *http.Client,
 	queue queue.Queue,
 	log audit.Log,
+	frequency time.Duration,
 	consumedSegments, consumedRecords metrics.Counter,
 	replicatedSegments, replicatedRecords metrics.Counter,
 	failedSegments, failedRecords metrics.Counter,
@@ -61,6 +63,7 @@ func New(
 		client:             client,
 		queue:              queue,
 		log:                log,
+		frequency:          frequency,
 		activeSince:        time.Time{},
 		activeTargetAge:    defaultActiveTargetAge,
 		activeTargetSize:   defaultActiveTargetSize,
@@ -84,7 +87,7 @@ func New(
 // Run consumes segments from the queue, and replicates them to the endpoint.
 // Run returns when Stop is invoked.
 func (c *Consumer) Run() {
-	step := time.NewTicker(10 * time.Millisecond)
+	step := time.NewTicker(c.frequency)
 	defer step.Stop()
 
 	state := c.gather

--- a/pkg/consumer/consumer_test.go
+++ b/pkg/consumer/consumer_test.go
@@ -48,6 +48,7 @@ func TestConsumer(t *testing.T) {
 		consumer := New(client,
 			queue,
 			audit,
+			time.Second,
 			consumedSegments,
 			consumedRecords,
 			replicatedSegments,


### PR DESCRIPTION
The following commit adds the ability to change the frequency of courier
depending on what environmental values you pass in.

The default for the frequency flag is now 1s instead of 10ms